### PR TITLE
Link label change

### DIFF
--- a/index.es.md
+++ b/index.es.md
@@ -79,7 +79,7 @@ Por “contenido” web se hace referencia, generalmente, a la información que 
 Las pautas WCAG se aplican al contenido dinámico, multimedia, “móvil”, etc. También se pueden aplicar a tecnologías de la información y la comunicación (TIC) no relacionadas con la web, como se explica en [WCAG2ICT](/standards-guidelines/wcag/non-web-ict/).
 
 Información sobre las pautas WCAG:
-- [Resumen de WCAG](  /standards-guidelines/wcag/)
+- [Introducción a las WCAG](  /standards-guidelines/wcag/)
 - [[WCAG 2.1 de un vistazo]](/standards-guidelines/wcag/glance/)
 - [Cómo seguir las pautas WCAG 2 (Guía rápida)](https://www.w3.org/WAI/WCAG21/quickref/)
 - [Estándar WCAG 2.0](https://www.w3.org/TR/WCAG20/)

--- a/index.es.md
+++ b/index.es.md
@@ -79,7 +79,7 @@ Por “contenido” web se hace referencia, generalmente, a la información que 
 Las pautas WCAG se aplican al contenido dinámico, multimedia, “móvil”, etc. También se pueden aplicar a tecnologías de la información y la comunicación (TIC) no relacionadas con la web, como se explica en [WCAG2ICT](/standards-guidelines/wcag/non-web-ict/).
 
 Información sobre las pautas WCAG:
-- [Introducción a las WCAG](  /standards-guidelines/wcag/)
+- [[Introducción a las WCAG]](/standards-guidelines/wcag/)
 - [[WCAG 2.1 de un vistazo]](/standards-guidelines/wcag/glance/)
 - [Cómo seguir las pautas WCAG 2 (Guía rápida)](https://www.w3.org/WAI/WCAG21/quickref/)
 - [Estándar WCAG 2.0](https://www.w3.org/TR/WCAG20/)


### PR DESCRIPTION
Changed the text of the link to match the title of the linked document, which contains a more accurate translation.