### PR TITLE
Fix fork & edit links in multiple languages

### DIFF
--- a/content/index.cs.md
+++ b/content/index.cs.md
@@ -18,7 +18,7 @@ changelog: /standards-guidelines/changelog/
 layout: default
 github:
   repository: w3c/wai-std-gl-overview
-  path: index.cs.md   # Add the language shortcode to the middle of the filename, for example index.fr.md
+  path: content/index.cs.md   # Add the language shortcode to the middle of the filename, for example index.fr.md
 permalink: /standards-guidelines/cs   # Add the language shortcode to the end; for example /standards-guidelines/fr
 feedbackmail: wai@w3.org
 

--- a/content/index.es.md
+++ b/content/index.es.md
@@ -19,7 +19,7 @@ changelog: /standards-guidelines/changelog/
 layout: default
 github:
   repository: w3c/wai-std-gl-overview
-  path: index.es.md   # Add the language shortcode to the middle of the filename, for example index.fr.md
+  path: content/index.es.md   # Add the language shortcode to the middle of the filename, for example index.fr.md
 permalink: /standards-guidelines/es   # Add the language shortcode to the end; for example /standards-guidelines/fr
 feedbackmail: wai@w3.org
 

--- a/content/index.fr.md
+++ b/content/index.fr.md
@@ -20,7 +20,7 @@ changelog: /standards-guidelines/changelog/
 layout: default
 github:
   repository: w3c/wai-std-gl-overview
-  path: index.fr.md   # Add the language shortcode to the middle of the filename, for example index.fr.md
+  path: content/index.fr.md   # Add the language shortcode to the middle of the filename, for example index.fr.md
 permalink: /standards-guidelines/fr   # Add the language shortcode to the end; for example /standards-guidelines/fr
 feedbackmail: wai@w3.org
 

--- a/content/index.ko.md
+++ b/content/index.ko.md
@@ -18,7 +18,7 @@ changelog: /standards-guidelines/changelog/
 layout: default
 github:
   repository: w3c/wai-std-gl-overview
-  path: index.ko.md   # Add the language shortcode to the middle of the filename, for example index.fr.md
+  path: content/index.ko.md   # Add the language shortcode to the middle of the filename, for example index.fr.md
 permalink: /standards-guidelines/ko   # Add the language shortcode to the end; for example /standards-guidelines/fr
 feedbackmail: wai@w3.org
 

--- a/content/index.ru.md
+++ b/content/index.ru.md
@@ -16,7 +16,7 @@ ref: /standards-guidelines/   # Do not change this
 layout: default
 github:
   repository: w3c/wai-std-gl-overview
-  path: index.ru.md   # Add the language shortcode to the middle of the filename, for example index.fr.md
+  path: content/index.ru.md   # Add the language shortcode to the middle of the filename, for example index.fr.md
 permalink: /standards-guidelines/ru   # Add the language shortcode to the end; for example /standards-guidelines/fr
 feedbackmail: wai@w3.org
 

--- a/content/index.zh-hans.md
+++ b/content/index.zh-hans.md
@@ -16,7 +16,7 @@ changelog: /standards-guidelines/changelog/
 layout: default
 github:
   repository: w3c/wai-std-gl-overview
-  path: index.zh-hans.md   # Add the language shortcode to the middle of the filename, for example index.fr.md
+  path: content/index.zh-hans.md   # Add the language shortcode to the middle of the filename, for example index.fr.md
 permalink: /standards-guidelines/zh-hans   # Add the language shortcode to the end; for example /standards-guidelines/fr
 feedbackmail: wai@w3.org
 


### PR DESCRIPTION
Current links return 404 errors.

Translations concerned by the fix :
- Czech
- Spanish
- French
- Korean
- Russian
- Chinese, in simplified script