### PR TITLE
Update links to standards & update translations notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,27 @@
 [![Netlify Status](https://api.netlify.com/api/v1/badges/633e4cce-b7b1-45e8-a326-c4626b2d4c50/deploy-status)](https://app.netlify.com/sites/wai-std-gl-overview/deploys)
 ## Translation Notes
 
-[Image at the bottom](https://www.w3.org/WAI/content-images/wai-std-gl-overview/specs.png):  For now, it is OK to leave the image in English. (It only illustrates the information above, and does not provided substantial additional information.) We are working on an SVG version of that image, with support for translation. We will update this section and notify existing translators when it is ready.
+### Links to WCAG standards
+
+The page contains links to WCAG 2.0, 2.1 and 2.2.
+
+If an Authorized Translation of a WCAG standard has been published in your language, please point to the translated version.
+
+Example:
+
+```
+- [Le standard WCAG 2.0](https://www.w3.org/Translations/WCAG20-fr/)
+- [Le standard WCAG 2.1](https://www.w3.org/Translations/WCAG21-fr/)
+```
+
+If not, translate the link text but keep the link to the English version.
+
+Example:
+
+```
+- [Le standard WCAG 2.2](https://www.w3.org/TR/WCAG22//)
+```
+
+### [Image at the bottom](https://www.w3.org/WAI/content-images/wai-std-gl-overview/specs.png)
+
+For now, it is OK to leave the image in English. (It only illustrates the information above, and does not provided substantial additional information.) We are working on an SVG version of that image, with support for translation. We will update this section and notify existing translators when it is ready.

--- a/content/index.md
+++ b/content/index.md
@@ -1,36 +1,39 @@
 ---
-# Translation instructions are after the "#" character in this first section. They are comments that do not show up in the web page. You do not need to translate the instructions after #.
+# Translation instructions are after the "#" character in this first section. They are comments that do not show up in the web page. You do not need to translate the instructions after "#".
+# In this first section, do not translate the words before a colon. For example, do not translate "title:". Do translate the text after "title:"
 
-title: W3C Accessibility Standards Overview  # Do not translate "title:". Do translate the text after "title:".
+title: W3C Accessibility Standards Overview
 nav_title: "Standards/Guidelines" # A short title that is used in the navigation
 
-lang: en   # Change "en" to the translated language shortcode from https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
+lang: en  # Change "en" to the translated-language shortcode
 
-last_updated: 2024-01-15   # Put the date of this translation YYYY-MM-DD (with month in the middle)
-# translators: 
-# - name: "@@"   # Replace @@ with translator name
-#  link: @@
-# - name: "@@"   # Replace @@ with name, or delete this line if not multiple translators
+last_updated: 2024-02-29   # Put the date of this translation YYYY-MM-DD (with month in the middle)
+
+# translators: # remove from the beginning of this line and the lines below: "# " (the hash sign and the space)
+# - name: "Jan Doe"   # Replace Jan Doe with translator name
+# - name: "Jan Doe"   # Replace Jan Doe with name, or delete this line if not multiple translators
 # contributors:
-# - name: "@@"   # Replace @@ with contributor name, or delete this line if none
-# - name: "@@"   # Replace @@ with name, or delete this line if not multiple contributors
+# - name: "Jan Doe"   # Replace Jan Doe with contributor name, or delete this line if none
+# - name: "Jan Doe"   # Replace Jan Doe with name, or delete this line if not multiple contributors
 
-ref: /standards-guidelines/   # Do not change this
-changelog: /standards-guidelines/changelog/
-layout: default
 github:
   repository: w3c/wai-std-gl-overview
   path: content/index.md   # Add the language shortcode to the middle of the filename, for example index.fr.md
-permalink: /standards-guidelines/   # Add the language shortcode to the end; for example /standards-guidelines/fr
+
+permalink: /standards-guidelines/   # Add the language shortcode to the end, with no slash at the end. For example /path/to/file/fr
+ref: /standards-guidelines/   # Do not change this
+
+changelog: /standards-guidelines/changelog/ # Do not change this
+layout: default
 feedbackmail: wai@w3.org
 
 # In the footer below:
+# Do not change the dates
 # Do not translate or change CHANGELOG or ACKNOWLEDGEMENTS.
 # Translate the other words below, including "Date:" and "Editor:"
 # Translate the Working Group name. Leave the Working Group acronym in English.
-# Do not change the dates in the footer below.
 footer: >
-  <p><strong>Date:</strong> Updated 29 June 2022. CHANGELOG.</p>
+  <p><strong>Date:</strong> Updated 29 February 2024. CHANGELOG.</p>
   <p><strong>Editor:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a>.</p>
   <p>Developed with input from the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>).</p>
 
@@ -85,11 +88,11 @@ WCAG applies to dynamic content, multimedia, "mobile", etc. WCAG can also be app
 WCAG 2 info:
 - [WCAG Overview](/standards-guidelines/wcag/)
 - [[WCAG 2.1 at a Glance]](/standards-guidelines/wcag/glance/)
-- [How to Meet WCAG 2 (Quick Reference)](https://www.w3.org/WAI/WCAG21/quickref/)
+- [How to Meet WCAG 2 (Quick Reference)](https://www.w3.org/WAI/WCAG22/quickref/)
 - [[WCAG 2 Translations]](/standards-guidelines/wcag/translations/)
-- [WCAG 2.0 Standard](https://www.w3.org/TR/WCAG20/)
-- [WCAG 2.1 Standard](https://www.w3.org/TR/WCAG21/), [[What’s New in WCAG 2.1]](/standards-guidelines/wcag/new-in-21/)
 - [WCAG 2.2 Standard](https://www.w3.org/TR/WCAG22/), [[What's New in WCAG 2.2]](/standards-guidelines/wcag/new-in-22/)
+- [WCAG 2.1 Standard](https://www.w3.org/TR/WCAG21/), [[What’s New in WCAG 2.1]](/standards-guidelines/wcag/new-in-21/)
+- [WCAG 2.0 Standard](https://www.w3.org/TR/WCAG20/)
 
 ### Authoring Tool Accessibility Guidelines (ATAG) {#atag}
 
@@ -128,7 +131,7 @@ The ARIA suite includes <abbr title="application programming interface">API</abb
 ARIA info:
 - [WAI-ARIA Overview](/standards-guidelines/aria/) – includes a [list and description of modules and API mappings](/standards-guidelines/aria/#versions)
 - [WAI-ARIA Authoring Practices](https://www.w3.org/TR/wai-aria-practices/)
-- [WAI-ARIA 1.1 Standard](https://www.w3.org/TR/wai-aria-1.1/)
+- [WAI-ARIA 1.2 Standard](https://www.w3.org/TR/wai-aria-1.2/)
 
 ### Audio and Video {#multimedia}
 

--- a/content/index.md
+++ b/content/index.md
@@ -6,7 +6,7 @@ nav_title: "Standards/Guidelines" # A short title that is used in the navigation
 
 lang: en   # Change "en" to the translated language shortcode from https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
 
-last_updated: 2022-06-29   # Put the date of this translation YYYY-MM-DD (with month in the middle)
+last_updated: 2024-01-15   # Put the date of this translation YYYY-MM-DD (with month in the middle)
 # translators: 
 # - name: "@@"   # Replace @@ with translator name
 #  link: @@
@@ -89,7 +89,7 @@ WCAG 2 info:
 - [[WCAG 2 Translations]](/standards-guidelines/wcag/translations/)
 - [WCAG 2.0 Standard](https://www.w3.org/TR/WCAG20/)
 - [WCAG 2.1 Standard](https://www.w3.org/TR/WCAG21/), [[What’s New in WCAG 2.1]](/standards-guidelines/wcag/new-in-21/)
-- [[What's New in WCAG 2.2 Working Draft]](/standards-guidelines/wcag/new-in-22/)
+- [WCAG 2.2 Standard](https://www.w3.org/TR/WCAG22/), [[What's New in WCAG 2.2]](/standards-guidelines/wcag/new-in-22/)
 
 ### Authoring Tool Accessibility Guidelines (ATAG) {#atag}
 

--- a/content/index.md
+++ b/content/index.md
@@ -87,7 +87,7 @@ WCAG applies to dynamic content, multimedia, "mobile", etc. WCAG can also be app
 
 WCAG 2 info:
 - [WCAG Overview](/standards-guidelines/wcag/)
-- [[WCAG 2.1 at a Glance]](/standards-guidelines/wcag/glance/)
+- [[WCAG 2 at a Glance]](/standards-guidelines/wcag/glance/)
 - [How to Meet WCAG 2 (Quick Reference)](https://www.w3.org/WAI/WCAG22/quickref/)
 - [[WCAG 2 Translations]](/standards-guidelines/wcag/translations/)
 - [WCAG 2.2 Standard](https://www.w3.org/TR/WCAG22/), [[What's New in WCAG 2.2]](/standards-guidelines/wcag/new-in-22/)


### PR DESCRIPTION
- Add link to WCAG 2.2 standard
- ARIA 1.2 instead of ARIA 1.1
- Change standards order : WCAG 2.2 > 2.1 > 2.0
- Update Translation Notes: when to link to a translated version and when to link to an original version.

### 🌐 Impact on translations:
- Recently Updated: French
- In-progress Updates: Indonesian
- Other outdated translations: Arabic, Chinese (Simplified), Czech, Korean, Russian, Spanish.